### PR TITLE
docs: typo's & structure

### DIFF
--- a/docs/neo-n3/README.md
+++ b/docs/neo-n3/README.md
@@ -52,7 +52,7 @@ __Maven__
 
 ### Devpack
 
-The neow3j devpack is a Java library that provides the Neo-specific functionality required to write a smart contract. If
+The neow3j devpack is a Java library that provides the Neo-specific functionality required to write smart contracts. If
 you want to play around with the devpack, add the `io.neow3j:devpack` dependency to your project.
 
 __Gradle__

--- a/docs/neo-n3/README.md
+++ b/docs/neo-n3/README.md
@@ -52,7 +52,7 @@ __Maven__
 
 ### Devpack
 
-The neow3j devpack is a Java library that provides the Neo-specific functionality required to write smart contract. If
+The neow3j devpack is a Java library that provides the Neo-specific functionality required to write a smart contract. If
 you want to play around with the devpack, add the `io.neow3j:devpack` dependency to your project.
 
 __Gradle__

--- a/docs/neo-n3/dapp_development/interacting_with_a_node.md
+++ b/docs/neo-n3/dapp_development/interacting_with_a_node.md
@@ -32,7 +32,7 @@ if necessary.
 Now that we have a `Neow3j` instance set up, we can start exploring possible interactions with the Neo blockchain. Most
 methods on `Neow3j` construct and return a `Request` object that defines the request and the expected response format. 
 Call `send()` on that request to actually send it to the Neo node. The returned type will be a subclass of `Response`.
-To make sure you don't run into unexptected `NullPointerException`s you can call `hasError()`, `getError()`, or
+To make sure you don't run into unexpected `NullPointerException`s you can call `hasError()`, `getError()`, or
 `throwOnError()` on the response object and handle errors smoothly before trying to access any other response data.
 
 Another set of methods on `Neow3j` are based on RxJava and return `Observable`s that you can subscribe to. They are
@@ -69,7 +69,7 @@ neow3j.subscribeToNewBlocksObservable(true)
 
 ## Inspecting a transaction
 
-You can retrieve transaction information with the block subscritptions from the last sections but you can also be more
+You can retrieve transaction information with the block subscriptions from the last sections but you can also be more
 specific and fetch information about single transactions, e.g., if you sent a transaction to a node and now want to
 check its state on the blockchain. 
 
@@ -83,7 +83,7 @@ Transaction tx = response.getTransaction();
 ```
 
 This `Transaction` object will contain all the information about the transaction, e.g., the fees paid for it, the block
-it was included, or how many blocks have been added since the transadtion was included in a block. If you require the
+it was included in, or how many blocks have been added since the transaction was included in a block. If you require the
 transaction in its raw byte array form you can use the `getRawTransaction` method instead. It will provide a
 Base64-encoded String of the transaction bytes.
 
@@ -119,7 +119,7 @@ The stack included in the application logs will contain all the stack items that
 return stack is made up of one return value that is at index 0. You will need to know what type of stack item the
 invocation returns to be able to interpret it correctly.  
 
-Next to the return value you can also check what notification have been triggered by the transaction. The applications
+Next to the return value you can also check what notifications have been triggered by the transaction. The applications
 log's notifications are one way to track activities of a  smart contract. Currently there is no convenient way to follow
 a smart contract. You will need to subscribe to new blocks, go through all transaction's application logs, and check if
 the logs contain notifications fired by the contract by comparing the contract hash to `notification.getContract()`.

--- a/docs/neo-n3/dapp_development/interacting_with_a_node.md
+++ b/docs/neo-n3/dapp_development/interacting_with_a_node.md
@@ -133,7 +133,7 @@ necessary methods to interact and make use of such wallets.
 First a wallet needs to be opened.
 
 ```java
-NeoOpenWallet response = neow.openWallet("/path/to/wallet.json", "walletPassword").send();
+NeoOpenWallet response = neow3j.openWallet("/path/to/wallet.json", "walletPassword").send();
 if (response.hasError()) {
     throw new Exception("Failed to open walled. Error message: " + response.getError().getMessage());
 }
@@ -148,7 +148,7 @@ if (response.getOpenWallet()) {
 Now, with the open wallet, you can list the accounts in that wallet.
 
 ```java
-NeoListAddress response = neow.listAddress().send();
+NeoListAddress response = neow3j.listAddress().send();
 if (response.hasError()) {
     throw new Exception("Failed to fetch wallet accounts. Error message: " + response.getError().getMessage());
 }
@@ -158,7 +158,7 @@ List<NeoAddress> listOfAddresses = response.getAddresses();
 Check the wallets balances.
 
 ```java
-NeoGetWalletBalance response = neow.getWalletBalance(NeoToken.SCRIPT_HASH).send();
+NeoGetWalletBalance response = neow3j.getWalletBalance(NeoToken.SCRIPT_HASH).send();
 if (response.hasError()) {
     throw new Exception("Failed to get wallet balance. Error message: " + response.getError().getMessage());
 }
@@ -168,7 +168,7 @@ String balance = response.getWalletBalance().getBalance();
 And, in the end, close the wallet.
 
 ```java
-NeoCloseWallet response = neow.closeWallet().send();
+NeoCloseWallet response = neow3j.closeWallet().send();
 if (response.hasError()) {
     throw new Exception("Failed to close the  wallet. Error message: " + response.getError().getMessage());
 }

--- a/docs/neo-n3/dapp_development/preliminaries.md
+++ b/docs/neo-n3/dapp_development/preliminaries.md
@@ -19,9 +19,9 @@ aware of when constructing a `Hash160` or `Hash256`.
 
 ## NeoVM Stack Items
 
-When invoking a contract on the Neo blockchain, the result of that invocation is a list of items that are left on the
-NeoVM's stack at the end of the invocation. The NeoVM is the virtual machine on which all smart contract code
-isexecuted. These items are called stack items and are represented by the `StackItem` class in neow3j SDK. Stack items
+The NeoVM is the virtual machine on which all smart contract code is executed. When invoking a contract on the 
+Neo blockchain, the result of that invocation is a list of items that are left on the NeoVM's stack at the end of the
+ invocation. These items are called stack items and are represented by the `StackItem` class in neow3j SDK. Stack items
 can be one of several defined types that exist on the NeoVM and they have to be mapped into Java types when the SDK
 receives them from a Neo node. This mapping is not a simple one-to-one mapping but leaves space for more interpretation.
 For example, a stack item containing an integer can be interpreted as a boolean value if it is in the range of 0 and 1.

--- a/docs/neo-n3/dapp_development/smart_contracts.md
+++ b/docs/neo-n3/dapp_development/smart_contracts.md
@@ -4,7 +4,7 @@ To deploy, invoke or just retrieve information about any contract's state on the
 can be used. It is the most generic class in the neow3j SDK that models a contract. All other contract classes are
 subclasses of this one. On one hand, `SmartContract` offers methods to invoke a contract on the blockchain with the
 result of an actual state change. On the other hand, you can use it to simulate an invocation without actually inducing
-state chagnes. The latter is also used when the invocation only performs read actions. 
+state changes. The latter is also used when the invocation only performs read actions. 
 
 The only method that creates an actual transaction is `invokeFunction(...)`. It builds a script based on the provided
 function name and contract parameters and constructs a `TransactionBuilder` with it. The returned transaction builder
@@ -162,7 +162,7 @@ and `GasToken`. The other available contract classes are discussed below.
 
 ### ContractManagement
 
-The `ContractManagement` contract is a Neo native contract that, as it's name suggests, can be used to manage other
+The `ContractManagement` contract is a Neo native contract that, as its name suggests, can be used to manage other
 contracts. More precisely, it allows you to deploy, update, and delete a contract. In the neow3j SDK the update and
 delete methods cannot be used, because they can only be called from within another contract. But, the deploy method is
 available and allows you to deploy new contracts with neow3j. For example:
@@ -174,7 +174,7 @@ Transaction tx = new ContractManagement(neow3j)
         .sign();
 ```
 
-Producing the necessary NEF (Neo Executable Format) file and contractd manifest is not discussed here but are part of
+Producing the necessary NEF (Neo Executable Format) file and contract manifest is not discussed here but are part of
 the Contract Development [section]().
 
 There are two other methods on `ContracManagement`. They are concerned with the minimum deployment fee. The getter
@@ -194,7 +194,7 @@ transaction is signed by committee members.
 ### RoleManagement
 
 The `RoleManagament` contract is used to assign roles to nodes in the network. A node can be a state validator, an
-oracle node, or a NeoFS "Alphabet" node (respondible for consensus on NeoFS sidechain). 
+oracle node, or a NeoFS "Alphabet" node (responsible for consensus on NeoFS sidechain). 
 
 The designation of a node to a role can only be done via the Neo committee. But you can check the role assignments with
 the `getDesignatedRole(...)` method.
@@ -203,7 +203,7 @@ the `getDesignatedRole(...)` method.
 ### NeoNameService
 
 The `NeoNameService` is not a native contract but managed by the Neo core team. The script hash of this contract is not
-known to neow3j and has to be provided by the developer when constructing an instance of `NeoNameService`. As it's name
+known to neow3j and has to be provided by the developer when constructing an instance of `NeoNameService`. As its name
 suggest the name service contract provides the possibility to map a name to an owner account. You can read more about it
 in the official [Neo Docs](https://docs.neo.org/docs/en-us/reference/nns.html).
 

--- a/docs/neo-n3/dapp_development/token_contracts.md
+++ b/docs/neo-n3/dapp_development/token_contracts.md
@@ -89,7 +89,7 @@ for divisible tokens are not allowed to be used for non-divisible tokens, vice-v
 
 Both divisible and non-divisible token contracts implement the method `balanceOf(owner)`. It simply returns the number
 of tokens owned by the given address. On divisible tokens this includes fractional amounts of tokens. To get the
-fracitonal amount owned of a specific token, you can use the method `balanceOf(owner, tokenId)` that is specifically
+fractional amount owned of a specific token, you can use the method `balanceOf(owner, tokenId)` that is specifically
 implemented by divisible tokens.
 
 Further, NFTs provide the methods `tokens`, `tokensOf` and `ownerOf`. The method `ownerOf` returns the single owner of a
@@ -101,7 +101,7 @@ Similar to the overloads on the `FungibleToken` class (see previous section), `N
 overloads for the sender address to be either an `Account` or `Hash160`, and for adding a contract parameter that is
 passed to the `onNep11Payment` method if the receiver is a smart contract.
 
-Here's an example for sending 200 fractions of the token with ID 1. The factional amount has to be in accordance with
+Here's an example for sending 200 fractions of the token with ID 1. The fractional amount has to be in accordance with
 the number of decimals the token can have. You can fetch the number of decimals via the `getDecimals()` method or
 calculate the amount via the `toFractions(...)` method.
 

--- a/docs/neo-n3/dapp_development/transactions.md
+++ b/docs/neo-n3/dapp_development/transactions.md
@@ -23,7 +23,7 @@ when building the transaction. Although, you do have the option to add an additi
 Witnesses can only be added to the `Transaction` object and not to the builder because they usually depend on the
 serialized transaction for producing a signature.
 
-The properties called *nonce*, *validUntilBlock*, and *version* will also be set automatically if not set explicitely.
+The properties called *nonce*, *validUntilBlock*, and *version* will also be set automatically if not set explicitly.
 The *nonce* prevents replay attacks in which the exact same transaction is copied and sent again. Its default value is
 set at random by the transaction builder. The *validUntilBlock* value determines for how long the transaction will
 remain valid before it is included in a block. If it does not get included before that time runs out, it will be
@@ -36,7 +36,7 @@ discussed here. Neow3j has many classes that will provide you with a `Transactio
 script.  
 The transaction signers are used to pay for the transaction fees and might be required by the transaction's script for
 witness checks. The order of the signers is important because only the first signer will be used to pay for the
-transaction fees. You can set it explicitely with the `firstSigner(Hash160 account)` method or use the more general
+transaction fees. You can set it explicitly with the `firstSigner(Hash160 account)` method or use the more general
 `signers(Signer... signers)` method. Signers are associated with a witness scope that restricts how their witness on the
 transaction can be used in an invocation. For example, if a signer is only needed for fee payment the witness scope can
 be reduced to *None*. There are two signer classes to be aware of. The `AccountSigner` and the `ContractSigner`. Use

--- a/docs/neo-n3/dapp_development/wallets_and_accounts.md
+++ b/docs/neo-n3/dapp_development/wallets_and_accounts.md
@@ -87,7 +87,7 @@ The first two methods can be used for single- and multi-sig accounts. The verifi
 the NEP6Account's script - holds all information needed about the multi-sig account. This includes the signing
 threshold, the number of participants, and the involved public keys.  
 In the latter two methods there is now verification script available. Therefore, one or both of signing threshold and
-number of participants has to be specified explicitely in order such that the multi-sig account can be used as a signer in
+number of participants has to be specified explicitly in order such that the multi-sig account can be used as a signer in
 transactions. The `TransactionBuilder` needs the signing threshold and number of participants to determine the network
 fee that has to be paid for signing with the account.
 

--- a/docs/neo-n3/dapp_development/wallets_and_accounts.md
+++ b/docs/neo-n3/dapp_development/wallets_and_accounts.md
@@ -83,18 +83,18 @@ Multi-signature accounts can be created with the following methods:
 - `createMultiSigAccount(List<ECPublicKey> publicKeys, int signingThreshold)`
 - `createMultiSigAccount(String address, int signingThreshold, int nrOfParticipants)`
 
-The frist two methods can be used for single- and multi-sig accounts. The verification script - which is available in
+The first two methods can be used for single- and multi-sig accounts. The verification script - which is available in
 the NEP6Account's script - holds all information needed about the multi-sig account. This includes the signing
 threshold, the number of participants, and the involved public keys.  
-In the latter two methods there is now verificaiton script available. Therfore, one or both of signing threshold and
-number of participants has to be specified explicitely in order that the multi-sig account can be used as a signer in
+In the latter two methods there is now verification script available. Therefore, one or both of signing threshold and
+number of participants has to be specified explicitely in order such that the multi-sig account can be used as a signer in
 transactions. The `TransactionBuilder` needs the signing threshold and number of participants to determine the network
 fee that has to be paid for signing with the account.
 
 Multi-sig accounts do not hold EC key pairs. That would defeat the purpose of multi-sig accounts, because
 their key material should be spread over multiple entities.
 
-In the following example a new mutli-sig account is created from three public keys. It's signing threshold is two, i.e.,
+In the following example a new mutli-sig account is created from three public keys. Its signing threshold is two, i.e.,
 for a transaction signed by this account to be successful, at least two of the three participants have to sign.
 
 ```java

--- a/docs/neo-n3/smart_contract_development/neowjava.md
+++ b/docs/neo-n3/smart_contract_development/neowjava.md
@@ -5,7 +5,7 @@ though we are coding in Java the produced byte code is not meant for the JVM but
 of Java can be used and we call that subset NeowJava.
 
 Blockchain programmers need to be careful with computational resources because every step in their code costs GAS.
-You should **avoid using Java's standard library** and any library not explicitely implemented for smart contract
+You should **avoid using Java's standard library** and any library not explicitly implemented for smart contract
 purposes, because such libraries might contain unsupported code or code that is costly for execution on a blockchain.
 
 ## Types
@@ -278,9 +278,9 @@ public static class ExampleStruct {
 
 ## Inheritance
 
-Every Java class that doesn't explicitely extend another class is a subclass of `Object` and has access to its methods
+Every Java class that doesn't explicitly extend another class is a subclass of `Object` and has access to its methods
 even without overwriting them. However, NeowJava prohibits usage of `Object` methods like `toString` or `equals`
-if they are not explicitely overridden.
+if they are not explicitly overridden.
 
 Neow3j supports the inheritance of struct classes, i.e., classes annotated with `@Struct`. You can use the keyword `extends`
 to inherit field variables from another struct. In the following example, by instantiating a `Car`, the created struct on the


### PR DESCRIPTION
Was reading the documentation and noticed some typo's. The change on the `NeoVM stack items` was discussed on Discord